### PR TITLE
Align class declarations with documented interfaces

### DIFF
--- a/source/gaa.cpp
+++ b/source/gaa.cpp
@@ -100,11 +100,12 @@ class Player : public Team
   void NumberOfPlayers();
   void PlayerNames();
   void PlayerHealth();
+  void PlayerFitness();
 
   private:
 };
 
-class Level : Team
+class Level : public Team
 {
   public:
 
@@ -118,7 +119,7 @@ class Attack : public Game
 {
   public:
 
-  void AttackNow();
+  void Attack();
   void AttackResult();
 
   private:


### PR DESCRIPTION
## Summary
- add the missing Player::PlayerFitness declaration promised in the design
- make Level inherit publicly from Team to expose the base interface
- rename Attack::AttackNow to Attack::Attack to match the documented API

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68e2fed53634832a81885c80d6aaa81c